### PR TITLE
can now set require https in auth settings

### DIFF
--- a/OpenFTTH.APIGateway/Startup.cs
+++ b/OpenFTTH.APIGateway/Startup.cs
@@ -102,7 +102,7 @@ namespace OpenFTTH.APIGateway
                         RequireSignedTokens = true,
                     };
                     _.MetadataAddress = $"{configuration.GetSection("Auth").GetValue<string>("Host")}/.well-known/openid-configuration";
-                    _.RequireHttpsMetadata = _env.IsProduction();
+                    _.RequireHttpsMetadata = configuration.GetSection("Auth").GetValue<bool>("RequireHttps");
                 });
 
             if (_env.IsProduction())

--- a/OpenFTTH.APIGateway/appsettings.copy.json
+++ b/OpenFTTH.APIGateway/appsettings.copy.json
@@ -20,7 +20,8 @@
     "Password": ""
   },
   "Auth": {
-    "Host": ""
+    "Host": "",
+    "RequireHttps": true
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
This is done so when solution is running inside of a closed network we can connect to an openid connect server without https, since it won't be needed.