### PR TITLE
reduces the interval from default 2min to 30sec

### DIFF
--- a/OpenFTTH.APIGateway/Startup.cs
+++ b/OpenFTTH.APIGateway/Startup.cs
@@ -236,7 +236,10 @@ namespace OpenFTTH.APIGateway
 
             app.UseAuthentication();
 
-            app.UseWebSockets();
+            app.UseWebSockets(new WebSocketOptions
+            {
+                KeepAliveInterval = TimeSpan.FromSeconds(30)
+            });
 
             app.UseGraphQLWebSockets<OpenFTTHSchema>("/graphql");
 


### PR DESCRIPTION
This is done to handle the issues where cloud providers load balancers closes the connect after 1min of in-activity.