### PR TITLE
handling of authorization in subscriptions

### DIFF
--- a/OpenFTTH.APIGateway/Auth/AuthenticationListener.cs
+++ b/OpenFTTH.APIGateway/Auth/AuthenticationListener.cs
@@ -1,0 +1,93 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using GraphQL.Server.Transports.Subscriptions.Abstractions;
+using Newtonsoft.Json.Linq;
+using GraphQL.Server.Transports.AspNetCore;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Net.Http;
+
+namespace OpenFTTH.APIGateway.Auth
+{
+    public class AuthenticationListener : IOperationMessageListener
+    {
+        public static readonly string PRINCIPAL_KEY = "User";
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IUserContextBuilder _builder;
+
+        public AuthenticationListener(IHttpContextAccessor contextAccessor, IUserContextBuilder builder)
+        {
+            _httpContextAccessor = contextAccessor;
+            _builder = builder;
+        }
+
+        public ClaimsPrincipal ValidateCurrentToken(string token)
+        {
+            var myIssuer = "http://auth.openftth.local/auth/realms/openftth";
+
+            var httpClient = new HttpClient();
+            var t = new ConfigurationManager<OpenIdConnectConfiguration>($"{myIssuer}/.well-known/openid-configuration",
+                                                                         new OpenIdConnectConfigurationRetriever(),
+                                                                         new HttpDocumentRetriever(httpClient) { RequireHttps = false });
+
+            var result = t.GetConfigurationAsync().Result;
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var claimsPrincipal = tokenHandler.ValidateToken(token, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidIssuer = myIssuer,
+                ValidAudience = "account",
+                IssuerSigningKeys = result.SigningKeys
+
+            }, out SecurityToken validatedToken);
+
+            return claimsPrincipal;
+        }
+
+        public Task BeforeHandleAsync(MessageHandlingContext context)
+        {
+            if (context.Message.Type == MessageType.GQL_CONNECTION_INIT)
+            {
+                var payload = context.Message.Payload as JObject;
+
+                if (payload != null && payload.ContainsKey("Authorization"))
+                {
+                    var token = payload.Value<string>("Authorization");
+
+                    // Save the user to the http context
+                    try
+                    {
+                        var user = ValidateCurrentToken(token);
+                        _httpContextAccessor.HttpContext.User = user;
+                    }
+                    catch
+                    {
+                        return context.Terminate();
+                    }
+                }
+            }
+
+            // Always insert the http context user into the message handling context properties
+            // Note: any IDisposable item inside the properties bag will be disposed after this message is handled!
+            //  So do not insert such items here, but use something like 'context[PRINCIPAL_KEY] = [...]'
+            context.Properties[PRINCIPAL_KEY] = _httpContextAccessor.HttpContext?.User;
+
+            if (_httpContextAccessor.HttpContext?.User == null || !_httpContextAccessor.HttpContext.User.Identity.IsAuthenticated)
+            {
+                return context.Terminate();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task HandleAsync(MessageHandlingContext context) => Task.CompletedTask;
+        public Task AfterHandleAsync(MessageHandlingContext context) => Task.CompletedTask;
+    }
+}

--- a/OpenFTTH.APIGateway/GraphQL/Root/OpenFTTHSubscriptions.cs
+++ b/OpenFTTH.APIGateway/GraphQL/Root/OpenFTTHSubscriptions.cs
@@ -1,5 +1,4 @@
-﻿using GraphQL.Authorization;
-using GraphQL.Types;
+﻿using GraphQL.Types;
 using Microsoft.Extensions.Logging;
 using OpenFTTH.APIGateway.GraphQL.RouteNetwork.Subscriptions;
 using OpenFTTH.APIGateway.GraphQL.Schematic.Subscriptions;
@@ -8,11 +7,11 @@ namespace OpenFTTH.APIGateway.GraphQL.Root
 {
     public class OpenFTTHSubscriptions : ObjectGraphType
     {
-        public OpenFTTHSubscriptions(ILogger<OpenFTTHSubscriptions> logger, RouteNetworkEventSubscription routeNetworkEventSubscription, SchematicUpdatedSubscription schematicUpdatedSubscription)
+        public OpenFTTHSubscriptions(ILogger<OpenFTTHSubscriptions> logger,
+                                     RouteNetworkEventSubscription routeNetworkEventSubscription,
+                                     SchematicUpdatedSubscription schematicUpdatedSubscription)
         {
             Description = "GraphQL API for subscriping to various events in the Open FTTH system";
-
-            this.AuthorizeWith("Authenticated");
 
             routeNetworkEventSubscription.AddFields(this);
             schematicUpdatedSubscription.AddFields(this);

--- a/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
+++ b/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
@@ -1,5 +1,6 @@
 ﻿using GraphQL;
 using GraphQL.Resolvers;
+using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Types;
 using OpenFTTH.APIGateway.GraphQL.Schematic.Types;
 using OpenFTTH.Schematic.API.Model.DiagramLayout;
@@ -28,6 +29,15 @@ namespace OpenFTTH.APIGateway.GraphQL.Schematic.Subscriptions
                 ),
                 Subscriber = new EventStreamResolver<Diagram>(context =>
                 {
+                    var messageHandlingContext = context.UserContext.As<MessageHandlingContext>();
+                    var graphQLUserContext = messageHandlingContext.Get<GraphQLUserContext>("GraphQLUserContext");
+
+                    if (!graphQLUserContext.User.Identity.IsAuthenticated)
+                    {
+                        context.Errors.Add(new ExecutionError("Not authorized"));
+                        return null;
+                    }
+
                     if (!Guid.TryParse(context.Arguments["routeNetworkElementId"].ToString(), out Guid routeNetworkElementId))
                     {
                         context.Errors.Add(new ExecutionError("Wrong value for guid"));

--- a/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
+++ b/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
@@ -2,7 +2,9 @@
 using GraphQL.Resolvers;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Types;
+using Microsoft.Extensions.Options;
 using OpenFTTH.APIGateway.GraphQL.Schematic.Types;
+using OpenFTTH.APIGateway.Settings;
 using OpenFTTH.Schematic.API.Model.DiagramLayout;
 using System;
 
@@ -11,10 +13,12 @@ namespace OpenFTTH.APIGateway.GraphQL.Schematic.Subscriptions
     public class SchematicUpdatedSubscription
     {
         private readonly SchematicDiagramObserver _schematicDiagramObserver;
+        private readonly AuthSetting _authSetting;
 
-        public SchematicUpdatedSubscription(SchematicDiagramObserver schematicDiagramObserver)
+        public SchematicUpdatedSubscription(SchematicDiagramObserver schematicDiagramObserver, IOptions<AuthSetting> authSetting)
         {
             _schematicDiagramObserver = schematicDiagramObserver;
+            _authSetting = authSetting.Value;
         }
 
         public void AddFields(ObjectGraphType objectGraphType)
@@ -32,7 +36,7 @@ namespace OpenFTTH.APIGateway.GraphQL.Schematic.Subscriptions
                     var messageHandlingContext = context.UserContext.As<MessageHandlingContext>();
                     var graphQLUserContext = messageHandlingContext.Get<GraphQLUserContext>("GraphQLUserContext");
 
-                    if (!graphQLUserContext.User.Identity.IsAuthenticated)
+                    if (_authSetting.Enable && !graphQLUserContext.User.Identity.IsAuthenticated)
                     {
                         context.Errors.Add(new ExecutionError("Not authorized"));
                         return null;

--- a/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
+++ b/OpenFTTH.APIGateway/GraphQL/Schematic/Subscriptions/SchematicUpdatedSubscription.cs
@@ -28,7 +28,6 @@ namespace OpenFTTH.APIGateway.GraphQL.Schematic.Subscriptions
                 ),
                 Subscriber = new EventStreamResolver<Diagram>(context =>
                 {
-
                     if (!Guid.TryParse(context.Arguments["routeNetworkElementId"].ToString(), out Guid routeNetworkElementId))
                     {
                         context.Errors.Add(new ExecutionError("Wrong value for guid"));

--- a/OpenFTTH.APIGateway/Settings/AuthSetting.cs
+++ b/OpenFTTH.APIGateway/Settings/AuthSetting.cs
@@ -1,0 +1,10 @@
+namespace OpenFTTH.APIGateway.Settings
+{
+    public class AuthSetting
+    {
+        public string Host { get; set; }
+        public bool RequireHttps { get; set; }
+        public bool Enable { get; set; }
+        public string Audience { get; set; }
+    }
+}

--- a/OpenFTTH.APIGateway/Startup.cs
+++ b/OpenFTTH.APIGateway/Startup.cs
@@ -145,7 +145,7 @@ namespace OpenFTTH.APIGateway
             services.Configure<GeoDatabaseSetting>(databaseSettings =>
                             Configuration.GetSection("GeoDatabase").Bind(databaseSettings));
 
-            services.Configure<GeoDatabaseSetting>(authSettings =>
+            services.Configure<AuthSetting>(authSettings =>
                             Configuration.GetSection("Auth").Bind(authSettings));
 
             // Web stuff

--- a/OpenFTTH.APIGateway/appsettings.copy.json
+++ b/OpenFTTH.APIGateway/appsettings.copy.json
@@ -21,7 +21,9 @@
   },
   "Auth": {
     "Host": "",
-    "RequireHttps": true
+    "RequireHttps": true,
+    "Enable": true,
+    "Audience": "account"
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
We had issues with the default implementation of authorization for GraphQL subscriptions, so we had to roll our own middleware to handle it.