### PR TITLE
lock xunit dependency injection to major version 9

### DIFF
--- a/OpenFTTH.APIGateway.IntegrationTests/OpenFTTH.APIGateway.IntegrationTests.csproj
+++ b/OpenFTTH.APIGateway.IntegrationTests/OpenFTTH.APIGateway.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Xunit.DependencyInjection" Version="8.9.1" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="[9.9.0, 10)" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenFTTH.Schematic.Tests/OpenFTTH.Schematic.Tests.csproj
+++ b/OpenFTTH.Schematic.Tests/OpenFTTH.Schematic.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Xunit.DependencyInjection" Version="8.7.0" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="[9.9.0,10)" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenFTTH.UtilityGraphService.Tests/OpenFTTH.UtilityGraphService.Tests.csproj
+++ b/OpenFTTH.UtilityGraphService.Tests/OpenFTTH.UtilityGraphService.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="OpenFTTH.Results" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="Xunit.DependencyInjection" Version="8.3.0" />
+    <PackageReference Include="Xunit.DependencyInjection" Version="[9.9.0, 10)" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This is needed because major 10+ does only work with new xunit v3 and we use xunit v2.